### PR TITLE
chore: prepare instruction for generating ML data

### DIFF
--- a/examples/ML.ipynb
+++ b/examples/ML.ipynb
@@ -1,6 +1,38 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "062c36b9-1713-4676-8dcd-b551ab462a53",
+   "metadata": {},
+   "source": [
+    "# How to generate input and output data for our model\n",
+    "\n",
+    "## Inputs\n",
+    "\n",
+    "- **Geometry**: a set of primitives (triangles) with\n",
+    "  + variable size (number of primitives can vary from inputs);\n",
+    "  + shape of `[n_primitives, 3, coordinates : 3]`;\n",
+    "  + primitives order is **not** important.\n",
+    "- **TX** and **RX**: transmitting and receiving nodes with\n",
+    "  + variables number of **TX** or **RX**;\n",
+    "  + each node has shape `[coordinates : 3`];\n",
+    "  \n",
+    "> NOTE: the problem should be separable for each pair of (TX, RX). I.e., addressing the problem of path finding as if there were only one TX and one RX is ok.\n",
+    "\n",
+    "## Output\n",
+    "\n",
+    "- **Paths**: a sequence of sequences of coordinates such that:\n",
+    "  + the number of paths (i.e., the size of outer sequence) is variable;\n",
+    "  + the size of a given path (i.e., the size of any inner sequence) is variable, but can be **bounded** by some factor, usually referred to as the `max_depth`.\n",
+    "  \n",
+    "> NOTE: it could be interesting to favor the paths that have the shortest length.\n",
+    "  \n",
+    "In practive, paths are stored in a continuous tensor in memory. As such, Sionna uses a padding value to indicate missing path: `0.0`. This is useful, e.g., if there exists 5 paths from `tx_0` to `rx_0`, but only 3 paths from `tx_0` to `rx_1`.\n",
+    "\n",
+    "For shorter paths, i.e., paths that have less than `max_depth` interactions, one must use some post-processing to remove invalid vertices. An example of such post-processing can be found in the function [`sionna.rt.utils.paths_to_segments`](https://github.com/jeertmans/sionna/blob/machine-learning/sionna/rt/utils.py#L270)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "f2a3a3cf-b717-49be-8ecf-9552b9cdfb65",
@@ -13,7 +45,10 @@
     "import tensorflow as tf\n",
     "\n",
     "# Import Sionna RT components\n",
-    "from sionna.rt import load_scene, PlanarArray, Receiver, Transmitter"
+    "from sionna.rt import load_scene, PlanarArray, Receiver, Transmitter\n",
+    "\n",
+    "# For pretty printing\n",
+    "from textwrap import indent"
    ]
   },
   {
@@ -25,11 +60,11 @@
    },
    "outputs": [],
    "source": [
-    "seed = 1234\n",
+    "seed = 12\n",
     "\n",
     "# Load integrated scene\n",
     "\n",
-    "scene_name = \"munich\"\n",
+    "scene_name = \"simple\"\n",
     "\n",
     "if scene_name == \"simple\":\n",
     "    scene = load_scene(sionna.rt.scene.simple_street_canyon)\n",
@@ -58,8 +93,8 @@
     "\n",
     "# Too large values can cause OOM errors (or lags) on\n",
     "# larger scenes.\n",
-    "n_sources = 10\n",
-    "n_targets = 10\n",
+    "n_sources = 2\n",
+    "n_targets = 2\n",
     "\n",
     "min_x, min_y, min_z = scene.mi_scene.bbox().min\n",
     "max_x, max_y, max_z = scene.mi_scene.bbox().max\n",
@@ -96,6 +131,43 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "1c1d4536-f420-45a5-b4db-c325a40ff44e",
+   "metadata": {},
+   "source": [
+    "# Current Inputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5b45f0c-f04e-4083-8382-d6a9b62f0413",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# First input: geometry primitives\n",
+    "primitives = scene._solver._primitives\n",
+    "print(primitives.shape)\n",
+    "\n",
+    "# NOTE: Python's builtin dict should keep the insert ordering when iterating over transmitters\n",
+    "#       and receivers. So that the ith transmitters if tx_i.\n",
+    "#       This invariant is important since we use indexing in the paths to make a given path\n",
+    "#       correspond to as given (tx, rx) pair.\n",
+    "\n",
+    "i = 0\n",
+    "j = 1\n",
+    "\n",
+    "# Second input\n",
+    "tx = scene.transmitters[f\"tx_{i}\"].position\n",
+    "rx = scene.receivers[f\"rx_{i}\"].position\n",
+    "\n",
+    "print(f\"tx_{i} located at\", tx.numpy())\n",
+    "print(f\"rx_{i} located at\", rx.numpy())"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "195b3397-b442-4f03-9cb4-b3714e8b816b",
@@ -105,13 +177,21 @@
    "outputs": [],
    "source": [
     "# Compute propagation paths\n",
-    "paths = scene.compute_paths(max_depth=2,\n",
+    "paths = scene.compute_paths(max_depth=3,\n",
     "                            #method=\"exhaustive\",\n",
     "                            method=\"stochastic\", # For small scenes the method can be also set to \"exhaustive\"\n",
     "                            num_samples=1e6,     # Number of rays shot into random directions, too few rays can lead to missing paths\n",
     "                            seed=seed)           # By fixing the seed, reproducible results can be ensured\n",
     "\n",
     "scene.preview(paths, show_devices=True, show_paths=True) # Use the mouse to focus on the visualized paths"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df4ccb98-91c3-4e6b-bf20-7a06fb26e986",
+   "metadata": {},
+   "source": [
+    "# Current Output"
    ]
   },
   {
@@ -125,7 +205,20 @@
    "source": [
     "# [max_depth, num_targets, num_sources, max_num_paths, coordinates : 3]\n",
     "# max_num_paths cannot be predicted, but is always <= num_primitives**max_depth + 1\n",
-    "paths.vertices"
+    "vertices = paths.vertices\n",
+    "\n",
+    "_, _, _, max_num_paths, _ = vertices.shape\n",
+    "\n",
+    "print(\"Output's shape over all (tx,rx) pairs:\", vertices.shape)\n",
+    "\n",
+    "print(f\"tx_{i} located at\", tx.numpy())\n",
+    "print(f\"rx_{i} located at\", rx.numpy())\n",
+    "\n",
+    "# IMPORTANT: paths must be post-processed, see comment above.\n",
+    "for k in range(max_num_paths):\n",
+    "    path = vertices[:, j, i, k, :]\n",
+    "    pretty_path = indent(repr(path), \"\\t\")\n",
+    "    print(f\"\\nPath {k} from tx_{i} to rx_{j} is\", pretty_path, sep=\"\\n\")"
    ]
   }
  ],


### PR DESCRIPTION
Hello @nicoladicicco,

I added some documentation in current ML notebook about how input and output data are structured.

Note that there is a small caveat about how paths vertices are returned: put simply, you cannot just concatenate `[tx, path.vertices, rx]` altogether because one needs first to apply a mask (this is in addition to the padding values, that are used for something else).

I let you read the document, as well as this function that shows how to post-process paths (here, it is used to plot them):

https://github.com/jeertmans/sionna/blob/1f6bd43daaaad54c91702fb282aa36cd76d12b18/sionna/rt/utils.py#L270-L311

Let me know if you have any question!