### PR TITLE
Implement deep sets

### DIFF
--- a/sionna/models/deep_set.py
+++ b/sionna/models/deep_set.py
@@ -1,0 +1,51 @@
+from typing import Type
+
+import torch
+from torch import nn
+
+
+class EquivariantLayer(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int):
+        super().__init__()
+        self.Gamma = nn.Linear(in_channels, out_channels, bias=False)
+        self.Lambda = nn.Linear(in_channels, out_channels, bias=False)
+
+    def forward(self, x: torch.Tensor):
+        # x: [batch_size, n_elements, in_channels]
+        # return: [batch_size, n_elements, out_channels]
+        xm, _ = torch.max(x, dim=1, keepdim=True)
+        return self.Lambda(x) - self.Gamma(xm)
+
+
+class EquivariantDeepSet(nn.Module):
+    def __init__(self, in_channels: int, net_arch: list[int], act_fn: Type[nn.Module]) -> None:
+        super().__init__()
+        self.net = nn.Sequential()
+        net_arch = [in_channels] + net_arch
+        for i in range(len(net_arch) - 2):
+            self.net.append(EquivariantLayer(net_arch[i], net_arch[i + 1]))
+            self.net.append(act_fn())
+        self.net.append(EquivariantLayer(net_arch[-2], net_arch[-1]))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: [batch_size, n_elements, in_channels]
+        # return: [batch_size, n_elements, net_arch[-1]]
+        return torch.squeeze(self.net(x), dim=-1)
+
+
+class InvariantDeepSet(nn.Module):
+    def __init__(self, in_channels: int, psi_arch: list[int], rho_arch: list[int], act_fn: Type[nn.Module]) -> None:
+        super().__init__()
+        self.psi = EquivariantDeepSet(in_channels, psi_arch, act_fn)
+        rho_arch = [psi_arch[-1]] + rho_arch
+        self.rho = nn.Sequential()
+        for i in range(len(rho_arch) - 1):
+            self.rho.append(nn.Linear(rho_arch[i], rho_arch[i + 1]))
+            self.rho.append(act_fn())
+        self.rho.append(nn.Linear(rho_arch[-1], 1))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (batch_size, n_elements, in_channels)
+        # return: (batch_size, n_elements)
+        x = torch.mean(self.psi(x), dim=1)
+        return torch.squeeze(self.rho(x), dim=-1)

--- a/sionna/models/deep_set.py
+++ b/sionna/models/deep_set.py
@@ -18,10 +18,9 @@ class EquivariantLayer(nn.Module):
 
 
 class EquivariantDeepSet(nn.Module):
-    def __init__(self, in_channels: int, net_arch: list[int], act_fn: Type[nn.Module]) -> None:
+    def __init__(self, net_arch: list[int], act_fn: Type[nn.Module]) -> None:
         super().__init__()
         self.net = nn.Sequential()
-        net_arch = [in_channels] + net_arch
         for i in range(len(net_arch) - 2):
             self.net.append(EquivariantLayer(net_arch[i], net_arch[i + 1]))
             self.net.append(act_fn())
@@ -34,15 +33,15 @@ class EquivariantDeepSet(nn.Module):
 
 
 class InvariantDeepSet(nn.Module):
-    def __init__(self, in_channels: int, psi_arch: list[int], rho_arch: list[int], act_fn: Type[nn.Module]) -> None:
+    def __init__(self, psi_arch: list[int], rho_arch: list[int], act_fn: Type[nn.Module]) -> None:
         super().__init__()
-        self.psi = EquivariantDeepSet(in_channels, psi_arch, act_fn)
+        self.psi = EquivariantDeepSet(psi_arch, act_fn)
         rho_arch = [psi_arch[-1]] + rho_arch
         self.rho = nn.Sequential()
-        for i in range(len(rho_arch) - 1):
+        for i in range(len(rho_arch) - 2):
             self.rho.append(nn.Linear(rho_arch[i], rho_arch[i + 1]))
             self.rho.append(act_fn())
-        self.rho.append(nn.Linear(rho_arch[-1], 1))
+        self.rho.append(nn.Linear(rho_arch[-2], rho_arch[-1]))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # x: (batch_size, n_elements, in_channels)


### PR DESCRIPTION
Hi Jérome,

I have made a basic implementation of Deep Sets networks.
The equivariant Deep Sets take as an input a set, and output a fixed-size embedding **for each element in the set.**
The invariant Deep Sets take as an input a set, and output a fixed-size embedding **for the whole set.**
The class constructors allow for some customization of the Deep Sets architecture (number of layers, size of the layers, activation function).
The notation follows as closely as possible the maths in the [original Deep Sets paper](https://arxiv.org/pdf/1703.06114.pdf)

Before merging, I would like to complete this PR with the following:
1) Another nn.Module that, given a set, outputs a sequence (akin to [Gated Graph Neural Networks](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.conv.GatedGraphConv.html#torch_geometric.nn.conv.GatedGraphConv)
2) A basic unit test that checks input/output consistency of the modules.

In the meantime any feedback is appreciated :-)

Nick